### PR TITLE
[feat] Member Entity, MemberStatus, MemberRole 생성

### DIFF
--- a/src/main/java/com/wedit/weditapp/domain/member/domain/Member.java
+++ b/src/main/java/com/wedit/weditapp/domain/member/domain/Member.java
@@ -23,6 +23,9 @@ public class Member extends BaseTimeEntity {
     private String email;
 
     @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
     private String name;
 
     @Enumerated(EnumType.STRING)
@@ -38,19 +41,19 @@ public class Member extends BaseTimeEntity {
 
     // Builder를 통해서만 객체를 생성하도록 (일반 생성자는 protected)
     @Builder
-    private Member(String kakaoId, String email, String name, MemberRole role, String refresh_token, MemberStatus status) {
+    private Member(String kakaoId, String email, String name, MemberRole role, String password, MemberStatus status) {
         this.email = email;
         this.name = name;
         this.role = role != null ? role : MemberRole.USER;     // 유저 역할 기본값 USER
-        this.refresh_token = refresh_token;
+        this.password = password;
         this.status = status != null ? status : MemberStatus.ACTIVE; // 유저 상태 기본값 ACTIVE
     }
 
-    public static Member createUser(String email, String name, String refreshToken) {
+    public static Member createUser(String email, String name, String password) {
         return Member.builder()
                 .email(email)
                 .name(name)
-                .refresh_token(refreshToken)
+                .password(password)
                 .role(MemberRole.USER) // 기본값 USER
                 .status(MemberStatus.ACTIVE) // 기본값 ACTIVE
                 .build();

--- a/src/main/java/com/wedit/weditapp/domain/member/domain/Member.java
+++ b/src/main/java/com/wedit/weditapp/domain/member/domain/Member.java
@@ -19,9 +19,6 @@ public class Member extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "kakao_id", nullable = false, unique = true)
-    private String kakaoId;
-
     @Column(nullable = false)
     private String email;
 
@@ -32,18 +29,31 @@ public class Member extends BaseTimeEntity {
     @Column(name = "role", nullable = false)
     private MemberRole role;
 
+    @Column(nullable = false, unique = true)
+    private String refresh_token;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private MemberStatus status;
 
     // Builder를 통해서만 객체를 생성하도록 (일반 생성자는 protected)
     @Builder
-    private Member(String kakaoId, String email, String name, MemberRole role, MemberStatus status) {
-        this.kakaoId = kakaoId;
+    private Member(String kakaoId, String email, String name, MemberRole role, String refresh_token, MemberStatus status) {
         this.email = email;
         this.name = name;
         this.role = role != null ? role : MemberRole.USER;     // 유저 역할 기본값 USER
+        this.refresh_token = refresh_token;
         this.status = status != null ? status : MemberStatus.ACTIVE; // 유저 상태 기본값 ACTIVE
+    }
+
+    public static Member createUser(String email, String name, String refreshToken) {
+        return Member.builder()
+                .email(email)
+                .name(name)
+                .refresh_token(refreshToken)
+                .role(MemberRole.USER) // 기본값 USER
+                .status(MemberStatus.ACTIVE) // 기본값 ACTIVE
+                .build();
     }
 
     // 상태 변경 예시 메서드

--- a/src/main/java/com/wedit/weditapp/domain/member/domain/Member.java
+++ b/src/main/java/com/wedit/weditapp/domain/member/domain/Member.java
@@ -1,6 +1,53 @@
 package com.wedit.weditapp.domain.member.domain;
 
 import com.wedit.weditapp.domain.shared.BaseTimeEntity;
+import com.wedit.weditapp.domain.shared.MemberRole;
+import com.wedit.weditapp.domain.shared.MemberStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
+@Table(name = "members")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "kakao_id", nullable = false, unique = true)
+    private String kakaoId;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private MemberRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private MemberStatus status;
+
+    // Builder를 통해서만 객체를 생성하도록 (일반 생성자는 protected)
+    @Builder
+    private Member(String kakaoId, String email, String name, MemberRole role, MemberStatus status) {
+        this.kakaoId = kakaoId;
+        this.email = email;
+        this.name = name;
+        this.role = role != null ? role : MemberRole.USER;     // 유저 역할 기본값 USER
+        this.status = status != null ? status : MemberStatus.ACTIVE; // 유저 상태 기본값 ACTIVE
+    }
+
+    // 상태 변경 예시 메서드
+    public void deactivate() {
+        this.status = MemberStatus.INACTIVE;
+    }
 }

--- a/src/main/java/com/wedit/weditapp/domain/shared/MemberRole.java
+++ b/src/main/java/com/wedit/weditapp/domain/shared/MemberRole.java
@@ -1,6 +1,16 @@
 package com.wedit.weditapp.domain.shared;
 
+import lombok.Getter;
+
+@Getter
 public enum MemberRole {
-    USER,
-    ADMIN
+    USER("사용자"),
+    ADMIN("관리자"),
+    GUEST("게스트");
+
+    private final String roleType;
+
+    MemberRole(String roleType) {
+        this.roleType = roleType;
+    }
 }

--- a/src/main/java/com/wedit/weditapp/domain/shared/MemberRole.java
+++ b/src/main/java/com/wedit/weditapp/domain/shared/MemberRole.java
@@ -1,0 +1,6 @@
+package com.wedit.weditapp.domain.shared;
+
+public enum MemberRole {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/wedit/weditapp/domain/shared/MemberStatus.java
+++ b/src/main/java/com/wedit/weditapp/domain/shared/MemberStatus.java
@@ -1,6 +1,17 @@
 package com.wedit.weditapp.domain.shared;
 
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
 public enum MemberStatus {
-    ACTIVE,
-    INACTIVE
+    ACTIVE("활성화"),
+    INACTIVE("비활성화");
+
+    private final String statusType;
+
+    MemberStatus(String statusType) {
+        this.statusType = statusType;
+    }
 }

--- a/src/main/java/com/wedit/weditapp/domain/shared/MemberStatus.java
+++ b/src/main/java/com/wedit/weditapp/domain/shared/MemberStatus.java
@@ -1,0 +1,6 @@
+package com.wedit.weditapp.domain.shared;
+
+public enum MemberStatus {
+    ACTIVE,
+    INACTIVE
+}


### PR DESCRIPTION
## 개요
- closed #2 
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- 아직 완성 X
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
로그인 기능 구현에 필요한 Member Entity 생성과 Enum : MemberStatus, MemberRole 생성

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->
Entity 생성 시 @Setter와 @AllArgsConstuctor는 최대한 지양해야 된다고 알고 있어서 2개는 뺐습니다. 이유는 아래와 같습니다.
- @Setter를 사용하시면 나중에 JPA에서 setter로 entity를 수정할 경우 코드상과 DB상의 data consistency가 깨지기에 데이터가 잘못날라가거나 DB에 반영 안 될 수 있습니다.
- @AllArgsConstuctor를 사용할 경우, 불필요한 외부의존성이 증가하고 나중에 필드 순서에 따라 에러가 발생할 가능성이 높아 사용하지 않는 것을 지양합니다. 추가로 그래서 Entity 아래에 @Builder를 사용해서 생성자를 만들어놓았습니다.