### PR TITLE
[fix] 카카오 소셜 로그인 방식 수정

### DIFF
--- a/src/main/java/com/wedit/weditapp/global/auth/login/controller/AuthController.java
+++ b/src/main/java/com/wedit/weditapp/global/auth/login/controller/AuthController.java
@@ -1,0 +1,64 @@
+package com.wedit.weditapp.global.auth.login.controller;
+
+import com.wedit.weditapp.domain.member.domain.Member;
+import com.wedit.weditapp.domain.member.domain.repository.MemberRepository;
+import com.wedit.weditapp.global.auth.jwt.JwtProvider;
+import com.wedit.weditapp.global.error.ErrorCode;
+import com.wedit.weditapp.global.error.exception.CommonException;
+import com.wedit.weditapp.global.response.GlobalResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final JwtProvider jwtProvider;
+    private final MemberRepository memberRepository;
+
+    @Operation(summary = "사용자 정보 조회", description = "Access Token을 이용하여 사용자 정보를 가져옵니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자 정보 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰"),
+            @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 에러")
+    })
+    @GetMapping("/me")
+    public ResponseEntity<GlobalResponseDto<Map<String, String>>> getUserInfo(
+            @RequestHeader(value = "Authorization", required = false) String token) {
+
+        if (token == null || !token.startsWith("Bearer ")) {
+            throw new CommonException(ErrorCode.INVALID_TOKEN);
+        }
+
+        token = token.substring(7);
+
+        if (!jwtProvider.validateToken(token)) {
+            throw new CommonException(ErrorCode.EXPIRED_JWT_TOKEN);
+        }
+
+        String email = jwtProvider.extractEmail(token)
+                .orElseThrow(() -> new CommonException(ErrorCode.INVALID_JWT_SIGNATURE));
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        Map<String, String> userInfo = Map.of(
+                "email", member.getEmail(),
+                "name", member.getName()
+        );
+
+        return ResponseEntity.ok(GlobalResponseDto.success(userInfo));
+    }
+}
+

--- a/src/main/java/com/wedit/weditapp/global/auth/login/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/wedit/weditapp/global/auth/login/handler/OAuth2LoginFailureHandler.java
@@ -15,8 +15,16 @@ import java.io.IOException;
 public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
-        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-        response.getWriter().write("소셜 로그인 실패! 서버 로그를 확인해주세요.");
-        log.info("소셜 로그인에 실패했습니다. 에러 메시지 : {}", exception.getMessage());
+        if (exception.getMessage().contains("authorization_request_not_found")) {
+            log.warn("OAuth2 로그인 요청이 세션에서 만료되었습니다. (무시 가능)");
+            response.sendRedirect("/login"); // 로그인 페이지로 리다이렉트
+            return;
+        }
+
+        log.error("소셜 로그인 실패! 에러 메시지: {}", exception.getMessage());
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write("{\"error\": \"OAuth2 login failed\", \"message\": \"" + exception.getMessage() + "\"}");
     }
 }

--- a/src/main/java/com/wedit/weditapp/global/auth/login/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/wedit/weditapp/global/auth/login/handler/OAuth2LoginSuccessHandler.java
@@ -14,6 +14,8 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 @Slf4j
 @Component
@@ -36,17 +38,41 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         // 3. AccessToken & RefreshToken 발급 + DB 저장
         String accessToken = jwtProvider.createAccessToken(member.getEmail());
-        String refreshToken = member.getRefreshToken();
+        String refreshToken = member.getRefreshToken(); // 추후 Redis 추가할 때 변경
 
         if (refreshToken == null || !jwtProvider.validateToken(refreshToken)) {
             refreshToken = jwtProvider.createRefreshToken();
             member.updateRefreshToken(refreshToken);
             memberRepository.save(member);
-            log.info("새 Refresh Token 발급: {}", refreshToken);
+            log.info("새 Refresh Token 발급 및 저장 완료"); // 이거 보여주면 안되서 지움
         }
 
-        jwtProvider.sendAccessAndRefreshToken(response, accessToken, refreshToken);
+        // 5. Access Token은 JSON Body로 반환, Refresh Token은 HttpOnly Secure Cookie에 저장
+        jwtProvider.sendAccessTokenResponse(response, accessToken);
+        jwtProvider.addRefreshTokenCookie(response, refreshToken);
 
-        response.setStatus(HttpServletResponse.SC_OK);
+        // 로그인 성공 후 프런트 : `/redirect`로 이동 & 백엔드 : Access Token 보여주기
+        if (isFrontendAvailable("http://localhost:5173/redirect")) {
+            log.info("Redirecting to frontend: http://localhost:5173/redirect");
+            response.sendRedirect("http://localhost:5173/redirect");
+        } else {
+            log.warn("프론트엔드가 실행되지 않음. Access Token을 JSON 응답으로 반환합니다.");
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+        }
+    }
+
+    private boolean isFrontendAvailable(String url) {
+        try {
+            HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+            connection.setRequestMethod("HEAD");
+            connection.setConnectTimeout(1000);
+            connection.setReadTimeout(1000);
+            int responseCode = connection.getResponseCode();
+            return (200 <= responseCode && responseCode <= 399);
+        } catch (IOException e) {
+            log.warn("프론트엔드 서버({})가 실행되지 않음.", url);
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #67 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
이전의 로직에서는 8080포트에서 카카오 인가코드 요청 및 승인부터 JWT 토큰 발급까지 모두 이뤄지고 있는데 이게 백엔드에서만 모두 돌아가다보니 프런트 측 에서는 그냥 바라만 볼 수 있을 뿐, 추출을 한다거나 뭐 이렇게 건들이거나 뭘 할 수가 없다고 함
-> 카카오 소셜 로그인 버튼을 누르면 프런트 주소로 리다이렉트 되도록 추가 및 그때 API를 통해 액세스 토큰과 리프레쉬 토큰도 넘겨주기로 수정(일단 아직까지는 API를 만들기만 함)

아직 프런트 측이 배포를 하지 않았는데 http://localhost:5173/redirect로 리다이렉트되길 원함
-> 모든 로직이 끝나고 토큰이 발급되어 전달할 때 localhost:5173에서는 http://localhost:5173/redirect로 리다이렉트 되도록 하고 localhost:8080에서는 그냥 이전과 유사하게 Access Token을 보여주도록 수정

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항
<img width="1434" alt="스크린샷 2025-01-31 오후 5 20 54" src="https://github.com/user-attachments/assets/1ba38830-6fa6-44d6-8e02-cc48c217fc99" />
에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
<img width="714" alt="스크린샷 2025-01-31 오후 5 21 26" src="https://github.com/user-attachments/assets/ff22f56c-97e4-4384-af7c-e35abfddb59e" />



📣 **To Reviewers**
---
<!-- 전달사항 -->
