### PR TITLE
[refactor] 카카오 소셜 로그인 최종 로직 확정

### DIFF
--- a/src/main/java/com/wedit/weditapp/global/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wedit/weditapp/global/auth/jwt/JwtAuthenticationFilter.java
@@ -61,8 +61,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                             memberRepository.save(member);
 
                             // Access Token은 JSON Body로 반환, Refresh Token은 쿠키로 저장
-                            jwtProvider.sendAccessTokenResponse(response, newAccessToken);
-                            jwtProvider.addRefreshTokenCookie(response, newRefreshToken);
+                            jwtProvider.setAccessTokenHeader(response, newAccessToken);
+                            jwtProvider.setRefreshTokenCookie(response, newRefreshToken);
                             log.info("AccessToken 및 RefreshToken 재발급 완료");
                         },
                         () -> log.error("유효하지 않은 RefreshToken으로 재발급 시도")

--- a/src/main/java/com/wedit/weditapp/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/wedit/weditapp/global/auth/jwt/JwtProvider.java
@@ -54,8 +54,8 @@ public class JwtProvider {
     }
 
     // Refresh Token 생성
-    public String createRefreshToken() {
-        return buildToken(null, "RefreshToken", refreshTokenExpiry);
+    public String createRefreshToken(String email) {
+        return buildToken(email, "RefreshToken", refreshTokenExpiry);
     }
 
     // Access Token + Refresh Token 생성 로직
@@ -103,7 +103,7 @@ public class JwtProvider {
     }
 
     // 요청 쿠키에서 Refresh Token 추출
-    public Optional<String> resolveRefreshTokenFromCookie(HttpServletRequest request) {
+    public Optional<String> extractRefreshTokenFromCookie(HttpServletRequest request) {
         if (request.getCookies() == null) {
             return Optional.empty();
         }

--- a/src/main/java/com/wedit/weditapp/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/wedit/weditapp/global/auth/jwt/JwtProvider.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -31,11 +32,14 @@ public class JwtProvider {
     @Value("${jwt.refresh.expiration}")
     private long refreshTokenExpiry; // 만료 시간 : 1209600000 (2주)
 
+    @Value("${jwt.access.header}")
+    private String accessHeader;
+
     private Key key; // 실제 사용할 HMAC용 key 객체
 
     private static final String EMAIL_CLAIM = "email";
     private static final String BEARER = "Bearer ";
-    private static final String REFRESH_COOKIE_NAME = "refreshToken"; // 쿠키에 저장할 이름
+    private static final String REFRESH_COOKIE_NAME = "refreshToken";
 
 
     // SecretKey 초기화
@@ -72,21 +76,15 @@ public class JwtProvider {
         return builder.compact();
     }
 
-    // AccessToken : JSON Body로 반환
-    public void sendAccessTokenResponse(HttpServletResponse response, String accessToken) {
+    // Access Token 헤더에 설정
+    public void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
         response.setStatus(HttpServletResponse.SC_OK);
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-
-        try {
-            response.getWriter().write("{\"accessToken\": \"" + accessToken + "\"}");
-        } catch (Exception e) {
-            log.error("AccessToken JSON 응답 오류: {}", e.getMessage());
-        }
+        response.setHeader(accessHeader, BEARER + accessToken);
+        log.info("Access Token 헤더 설정 완료");
     }
 
     // Refresh Token : HttpOnly, Secure 쿠키로 설정
-    public void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+    public void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
         Cookie refreshCookie = new Cookie(REFRESH_COOKIE_NAME, refreshToken);
         refreshCookie.setHttpOnly(true); // JavaScript에서 접근 불가능
         refreshCookie.setSecure(true); // HTTPS 환경에서만 전송
@@ -94,30 +92,41 @@ public class JwtProvider {
         refreshCookie.setMaxAge((int) TimeUnit.MILLISECONDS.toSeconds(refreshTokenExpiry)); // 만료 시간 설정
 
         response.addCookie(refreshCookie);
-        log.info("Refresh Token이 쿠키에 저장되었습니다.");
+        log.info("Refresh Token 쿠키 저장 완료");
     }
 
-    // AccessToken에서 이메일 클레임 추출
-    public Optional<String> extractEmail(String accessToken) {
+    // HTTP 요청의 Authorization 헤더에서 Access Token 추출
+    public Optional<String> extractAccessToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(accessHeader))
+                .filter(headerValue -> headerValue.startsWith(BEARER))
+                .map(headerValue -> headerValue.substring(BEARER.length()));
+    }
+
+    // 요청 쿠키에서 Refresh Token 추출
+    public Optional<String> resolveRefreshTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) {
+            return Optional.empty();
+        }
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> REFRESH_COOKIE_NAME.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findAny();
+    }
+
+    // 토큰으로부터 email 클레임 추출
+    public Optional<String> extractEmail(String token) {
         try {
             Claims claims = Jwts.parser()
                     .verifyWith((SecretKey) key)
                     .build()
-                    .parseSignedClaims(accessToken)
+                    .parseSignedClaims(token)
                     .getPayload();
 
             return Optional.ofNullable(claims.get(EMAIL_CLAIM, String.class));
         } catch (JwtException e) {
-            log.error("유효하지 않은 AccessToken입니다. {}", e.getMessage());
+            log.error("토큰에서 email 클레임 추출 실패: {}", e.getMessage());
             return Optional.empty();
         }
-    }
-
-    // HTTP 요청의 Authorization 헤더에서 Bearer Token 추출
-    public Optional<String> extractAccessToken(HttpServletRequest request) {
-        return Optional.ofNullable(request.getHeader("Authorization"))
-                .filter(token -> token.startsWith("Bearer "))
-                .map(token -> token.substring(7)); // "Bearer " 제거 후 순수 토큰 반환
     }
 
     // Token 유효성 검증

--- a/src/main/java/com/wedit/weditapp/global/auth/login/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/wedit/weditapp/global/auth/login/handler/OAuth2LoginSuccessHandler.java
@@ -49,7 +49,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         // 5. Access Token은 JSON Body로 반환, Refresh Token은 HttpOnly Secure Cookie에 저장
         //jwtProvider.sendAccessTokenResponse(response, accessToken);
-        jwtProvider.addRefreshTokenCookie(response, refreshToken);
+        jwtProvider.setRefreshTokenCookie(response, refreshToken);
 
         // 로그인 성공 후 프런트 : `/redirect`로 이동 & 백엔드 : Access Token 보여주기
         if (isFrontendAvailable("http://localhost:5173/redirect")) {

--- a/src/main/java/com/wedit/weditapp/global/auth/login/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/wedit/weditapp/global/auth/login/handler/OAuth2LoginSuccessHandler.java
@@ -41,7 +41,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         String refreshToken = member.getRefreshToken(); // 추후 Redis 추가할 때 변경
 
         if (refreshToken == null || !jwtProvider.validateToken(refreshToken)) {
-            refreshToken = jwtProvider.createRefreshToken();
+            //refreshToken = jwtProvider.createRefreshToken();
             member.updateRefreshToken(refreshToken);
             memberRepository.save(member);
             log.info("새 Refresh Token 발급 및 저장 완료"); // 이거 보여주면 안되서 지움

--- a/src/main/java/com/wedit/weditapp/global/auth/login/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/wedit/weditapp/global/auth/login/handler/OAuth2LoginSuccessHandler.java
@@ -57,8 +57,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         jwtProvider.setRefreshTokenCookie(response, oldRefreshToken);
 
         // 6. 배포되는 서버용 - 원하는 페이지로 리다이렉트
-        log.info("리다이렉트: http://wedit.site/mainpage");
-        response.sendRedirect("http://wedit.site/mainpage");
+        log.info("리다이렉트: http://wedit.site/");
+        response.sendRedirect("http://wedit.site/");
 
         // 6. 로컬테스트용
         //response.setStatus(HttpServletResponse.SC_OK);


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #75 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 도메인이 배포가 되지 않은 환경에서 처음에는 Header에 Access Token과 Refresh Token 둘 다 담아서 보냈으나 해당 주소는 8080, 즉 백엔드 측의 배포된 서버로 보낸 것이기에 프런트엔드 측에서는 접근할 수가 없음 -> 그러나 그때 당시, 도메인이 배포되지 않은 상황이었고 전달 방식이 잘못된 줄 알고 전달 방식 재수정
- 재수정한 전달 방식 : Access Token은 Response Body로, Refresh Token은 Cookie로 전달 -> 당연히 도메인이 배포되지 않았으니 해당 프런트엔드 측에서 해당 토큰들을 추출할 수가 없음


<!---- Resolves: #(Isuue Number) -->
Access Token : Header
Refersh Token : Cookie
Redirect될 도메인 : http://wedit.site/mainpage (임시)

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

<로컬 테스트>
- Header에 담긴 Authentication 키(=Access Token)
<img width="1433" alt="스크린샷 2025-02-01 오후 5 43 31" src="https://github.com/user-attachments/assets/b6cbfe3e-74ef-4753-9e05-e47f119350ed" />

- Cookie 안에 담긴 소듕한 Refresh Token
<img width="1433" alt="스크린샷 2025-02-01 오후 5 43 38" src="https://github.com/user-attachments/assets/1026d1a1-8f9a-498f-8180-6775674a357c" />

- DB에 저장된 회원 정보

📣 **To Reviewers**
---
<!-- 전달사항 -->
추후 배포된 서버에서의 테스트가 모두 성공적으로 진행되면 Redis를 순차적으로 추가하면서 Member 엔티티와 레포에 있는 Refresh 관련 어튜리뷰트와 메서드 삭제 예정
