### PR TITLE
[refactor] access token 전달 방식 변경

### DIFF
--- a/src/main/java/com/wedit/weditapp/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/wedit/weditapp/global/auth/jwt/JwtProvider.java
@@ -135,16 +135,6 @@ public class JwtProvider {
         }
     }
 
-    public void expireCookie(HttpServletResponse response, String cookieName) {
-        Cookie cookie = new Cookie(cookieName, null);
-        cookie.setMaxAge(0);
-        cookie.setPath("/");
-        cookie.setHttpOnly(false);
-        cookie.setSecure(false);
-
-        response.addCookie(cookie);
-    }
-
     // Token 유효성 검증
     public boolean validateToken(String token) {
         try {

--- a/src/main/java/com/wedit/weditapp/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/wedit/weditapp/global/auth/jwt/JwtProvider.java
@@ -97,6 +97,28 @@ public class JwtProvider {
         log.info("Refresh Token 쿠키 저장 완료");
     }
 
+    // HttpOnly Secure 쿠키에서 Access Token 추출
+    public Optional<String> extractAccessCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) {
+            return Optional.empty();
+        }
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> ACCESS_COOKIE_NAME.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst();
+    }
+
+    // HttpOnly Secure 쿠키에서 Refresh Token 추출
+    public Optional<String> extractRefreshCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) {
+            return Optional.empty();
+        }
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> REFRESH_COOKIE_NAME.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst();
+    }
+
     // 토큰으로부터 email 클레임 추출
     public Optional<String> extractEmail(String token) {
         try {
@@ -111,6 +133,16 @@ public class JwtProvider {
             log.error("토큰에서 email 클레임 추출 실패: {}", e.getMessage());
             return Optional.empty();
         }
+    }
+
+    public void expireCookie(HttpServletResponse response, String cookieName) {
+        Cookie cookie = new Cookie(cookieName, null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        cookie.setHttpOnly(false);
+        cookie.setSecure(false);
+
+        response.addCookie(cookie);
     }
 
     // Token 유효성 검증

--- a/src/main/java/com/wedit/weditapp/global/auth/login/controller/AuthController.java
+++ b/src/main/java/com/wedit/weditapp/global/auth/login/controller/AuthController.java
@@ -9,12 +9,11 @@ import com.wedit.weditapp.global.response.GlobalResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -26,33 +25,33 @@ public class AuthController {
     private final JwtProvider jwtProvider;
     private final MemberRepository memberRepository;
 
-    @Operation(summary = "사용자 정보 조회", description = "Access Token을 이용하여 사용자 정보를 가져옵니다.")
+    @Operation(summary = "사용자 정보 갱신", description = "쿠키에 들어있는 Access Token을 이용하여 사용자 정보를 가져옵니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "사용자 정보 조회 성공"),
             @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰"),
             @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음"),
             @ApiResponse(responseCode = "500", description = "서버 에러")
     })
-    @GetMapping("/me")
-    public ResponseEntity<GlobalResponseDto<Map<String, String>>> getUserInfo(
-            @RequestHeader(value = "Authorization", required = false) String token) {
+    @GetMapping("/renew")
+    public ResponseEntity<GlobalResponseDto<Map<String, String>>> getUserInfo(HttpServletRequest request) {
+        // 1. 쿠키에서 Access Token 추출
+        String accessToken = jwtProvider.extractAccessCookie(request)
+                .orElseThrow(() -> new CommonException(ErrorCode.INVALID_TOKEN));
 
-        if (token == null || !token.startsWith("Bearer ")) {
-            throw new CommonException(ErrorCode.INVALID_TOKEN);
-        }
-
-        token = token.substring(7);
-
-        if (!jwtProvider.validateToken(token)) {
+        // 2. 토큰 유효성 검사
+        if (!jwtProvider.validateToken(accessToken)) {
             throw new CommonException(ErrorCode.EXPIRED_JWT_TOKEN);
         }
 
-        String email = jwtProvider.extractEmail(token)
+        // 3. 토큰에서 이메일(claim) 추출
+        String email = jwtProvider.extractEmail(accessToken)
                 .orElseThrow(() -> new CommonException(ErrorCode.INVALID_JWT_SIGNATURE));
 
+        // 4. DB에서 사용자 조회
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
 
+        // 5. 사용자 정보 구성
         Map<String, String> userInfo = Map.of(
                 "email", member.getEmail(),
                 "name", member.getName()

--- a/src/main/java/com/wedit/weditapp/global/auth/login/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/wedit/weditapp/global/auth/login/handler/OAuth2LoginSuccessHandler.java
@@ -53,14 +53,14 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         String newAccessToken = jwtProvider.createAccessToken(member.getEmail());
 
         // 5. Access Token -> 응답 헤더, Refresh Token -> HttpOnly Cookie
-        jwtProvider.setAccessTokenHeader(response, newAccessToken);
+        jwtProvider.setAccessTokenCookie(response, newAccessToken);
         jwtProvider.setRefreshTokenCookie(response, oldRefreshToken);
 
         // 6. 배포되는 서버용 - 원하는 페이지로 리다이렉트
         //log.info("리다이렉트: http://wedit.site/");
-        response.sendRedirect("http://localhost:5173/");
+        //response.sendRedirect("http://localhost:5173/");
 
         // 6. 로컬테스트용
-        //response.setStatus(HttpServletResponse.SC_OK);
+        response.setStatus(HttpServletResponse.SC_OK);
     }
 }

--- a/src/main/java/com/wedit/weditapp/global/auth/login/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/wedit/weditapp/global/auth/login/handler/OAuth2LoginSuccessHandler.java
@@ -57,10 +57,10 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         jwtProvider.setRefreshTokenCookie(response, oldRefreshToken);
 
         // 6. 배포되는 서버용 - 원하는 페이지로 리다이렉트
-        //log.info("리다이렉트: http://wedit.site/");
-        //response.sendRedirect("http://localhost:5173/");
+        log.info("리다이렉트: http://wedit.site/");
+        response.sendRedirect("http://localhost:5173/");
 
         // 6. 로컬테스트용
-        response.setStatus(HttpServletResponse.SC_OK);
+        //response.setStatus(HttpServletResponse.SC_OK);
     }
 }


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #80 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- CORS 설정 자체는 “Cross-Origin AJAX 통신에서 응답 헤더를 노출할 수 있느냐”를 결정할 뿐이며,
브라우저가 302 Redirect를 자동 처리해버리는 리다이렉트 응답에 대해서는 프론트엔드 코드가 응답 헤더를 직접 읽을 방법이 없다고 결론남
=> Access Token도 Header가 아닌 Cookie의 형태로 전달할 계획

- 프런트 측에서 로그인 상태변경을 감지하기 위한 사용자 정보 조회 API 구현
- 로그아웃 API 구현

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

<성공적으로 Cookie에 담긴 Access Token과 Refresh Token>
<img width="1433" alt="스크린샷 2025-02-02 오전 1 47 53" src="https://github.com/user-attachments/assets/a44c703e-4116-426b-a24c-4be415bccefc" />


<쿠키에 담긴 Access Token으로 백엔드 측 DB에 있는 사용자와 일치하는지 검사 후 정보 전달>
<img width="1433" alt="스크린샷 2025-02-02 오전 2 05 24" src="https://github.com/user-attachments/assets/7e0bb8cc-bacf-4df4-b2de-cdc9424d3532" />


<작동 시, 해당 사용자의 Access Token과 Refresh Token을 즉시 만료시켜 로그아웃 시킴>
<img width="1433" alt="스크린샷 2025-02-02 오전 2 10 23" src="https://github.com/user-attachments/assets/998200f6-63e7-4680-9cb8-bc825c62a654" />



📣 **To Reviewers**
---
<!-- 전달사항 -->
